### PR TITLE
Upload user profile

### DIFF
--- a/Breezy-Traveler/API.swift
+++ b/Breezy-Traveler/API.swift
@@ -212,7 +212,7 @@ extension BTAPIEndPoints: TargetType {
             return .requestJSONEncodable(loginUser)
         case .uploadUserProfileImage(let imageData):
             let body: [String: Any] = [
-                "payload": imageData,
+                "payload": imageData.base64EncodedString(),
                 "type": "image/png"
             ]
             

--- a/Breezy-Traveler/API.swift
+++ b/Breezy-Traveler/API.swift
@@ -14,6 +14,8 @@ enum BTAPIEndPoints {
     // Users
     case registerUser(UserRegister)
     case loginUser(UserLogin)
+    case uploadUserProfileImage(imageData: Data)
+    case userProfileImage(User)
 
     // Trips
     case createTrip(CreateTrip)
@@ -70,6 +72,12 @@ extension BTAPIEndPoints: TargetType {
 
         case .loginUser:
             return "/login"
+            
+        case .uploadUserProfileImage:
+            return "/userProfile"
+            
+        case .userProfileImage(let user):
+            return "/userProfile/\(user.profileImage ?? "no-image")"
 
         // Trips
         case .createTrip, .loadTrips:
@@ -142,6 +150,10 @@ extension BTAPIEndPoints: TargetType {
         // Users
         case .registerUser, .loginUser:
             return .post
+        case .uploadUserProfileImage:
+            return .post
+        case .userProfileImage:
+            return .get
 
         // Trips
         case .createTrip:
@@ -198,6 +210,15 @@ extension BTAPIEndPoints: TargetType {
             return .requestJSONEncodable(registerUser)
         case .loginUser(let loginUser):
             return .requestJSONEncodable(loginUser)
+        case .uploadUserProfileImage(let imageData):
+            let body: [String: Any] = [
+                "payload": imageData,
+                "type": "image/png"
+            ]
+            
+            return .requestParameters(parameters: body, encoding: URLEncoding.default)
+        case .userProfileImage:
+            return .requestPlain
 
         // Trips
         case .createTrip(let trip):
@@ -249,5 +270,19 @@ extension BTAPIEndPoints: TargetType {
             defaultHeaders["Authorization"] = "Token \(token)"
         }
         return defaultHeaders
+    }
+}
+
+extension TargetType {
+    var endpoint: URL {
+        return self.baseURL.appendingPathComponent(self.path)
+    }
+}
+
+extension User {
+    var profileUrl: URL {
+        let request = BTAPIEndPoints.userProfileImage(self)
+        
+        return request.endpoint
     }
 }

--- a/Breezy-Traveler/MyTripsViewController.swift
+++ b/Breezy-Traveler/MyTripsViewController.swift
@@ -106,11 +106,8 @@ class MyTripsViewController: UIViewController {
     }
     
     private func updateUI() {
-        if let savedProfileImage = userPersistence.userProfileImage {
-            profileImage.image = savedProfileImage
-        }
-        
         let user = UserPersistence.currentUser
+        profileImage.kf.setImage(with: user.profileUrl)
         usernameLabel.text = user.username
         emailLabel.text = user.email
         

--- a/Breezy-Traveler/NetworkingLayer+Users.swift
+++ b/Breezy-Traveler/NetworkingLayer+Users.swift
@@ -82,7 +82,7 @@ struct NetworkStack {
         }
     }
     
-    func upload(profile image: UIImage, callback: @escaping (Result<UIImage, UserfacingErrors>) -> ()) {
+    func upload(profile image: UIImage, callback: @escaping (Result<User, UserfacingErrors>) -> ()) {
         guard let imageData = UIImagePNGRepresentation(image) else {
             let err = UserfacingErrors.somethingWentWrong(message: "invalid image")
             
@@ -95,14 +95,14 @@ struct NetworkStack {
                 
                 switch response.statusCode {
                 case 200:
-                    guard let userImage = UIImage(data: response.data) else {
-                        assertionFailure("could not decode into an image")
+                    guard let user = try? JSONDecoder().decode(User.self, from: response.data) else {
+                        assertionFailure("JSON data not decodable")
                         
                         let errors = UserfacingErrors.somethingWentWrong()
                         return callback(.failure(errors))
                     }
                     
-                    callback(.success(userImage))
+                    callback(.success(user))
                     
                 case 413:
                     let errors = UserfacingErrors.somethingWentWrong(message: "payload too large")

--- a/Breezy-Traveler/NetworkingLayer+Users.swift
+++ b/Breezy-Traveler/NetworkingLayer+Users.swift
@@ -81,6 +81,52 @@ struct NetworkStack {
             }
         }
     }
+    
+    func upload(profile image: UIImage, callback: @escaping (Result<UIImage, UserfacingErrors>) -> ()) {
+        guard let imageData = UIImagePNGRepresentation(image) else {
+            let err = UserfacingErrors.somethingWentWrong(message: "invalid image")
+            
+            return callback(.failure(err))
+        }
+        
+        apiService.request(.uploadUserProfileImage(imageData: imageData)) { (result) in
+            switch result {
+            case .success(let response):
+                
+                switch response.statusCode {
+                case 200:
+                    guard let userImage = UIImage(data: response.data) else {
+                        assertionFailure("could not decode into an image")
+                        
+                        let errors = UserfacingErrors.somethingWentWrong()
+                        return callback(.failure(errors))
+                    }
+                    
+                    callback(.success(userImage))
+                    
+                case 413:
+                    let errors = UserfacingErrors.somethingWentWrong(message: "payload too large")
+                    return callback(.failure(errors))
+                    
+                case 401:
+                    let errors = UserfacingErrors.invalidCredentials()
+                    callback(.failure(errors))
+                    
+                default:
+                    let errors = UserfacingErrors.serverError(message: response.data)
+                    callback(.failure(errors))
+                }
+                
+            case .failure(let err):
+                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
+                callback(.failure(errors))
+            }
+        }
+    }
+    
+    func clearProfileImage(callback: @escaping (Result<User, UserfacingErrors>) -> ()) {
+        //TODO: erick-clear user profile image
+    }
 }
 
 

--- a/Breezy-Traveler/PersistenceUser.swift
+++ b/Breezy-Traveler/PersistenceUser.swift
@@ -44,58 +44,7 @@ class UserPersistence {
         }
     }
     
-    var userProfileImage: UIImage? {
-        set {
-            if let newImage = newValue {
-                let url = userProfileImageURL
-                
-                // Convert the UIImage into Data
-                guard let imageData = UIImagePNGRepresentation(newImage) else {
-                    return assertionFailure("failed to create data from image")
-                }
-                
-                // Use file manager to save the data
-                do {
-                    try imageData.write(to: url)
-                } catch {
-                    assertionFailure("\(error)")
-                }
-            } else {
-                
-                //try to delete image from storage
-                try? FileManager.default.removeItem(at: userProfileImageURL)
-            }
-        }
-        
-        get {
-            guard let imageData = try? Data(contentsOf: userProfileImageURL) else {
-                return nil
-            }
-            
-            if let image = UIImage(data: imageData) {
-                return image
-            } else {
-                assertionFailure("image not converted from data")
-                
-                return nil
-            }
-        }
-    }
-    
     private let currentUserKey: String = "currentUser"
-    
-    private var userProfileImageURL: URL {
-        
-        // Get the URL for where to save the image
-        guard let libraryDirectory = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first else {
-            fatalError("no access to this directory")
-        }
-        
-        // Create a filepath name for the image store
-        let url = libraryDirectory.appendingPathComponent("userProfile.png")
-        
-        return url
-    }
     
     static var currentUser: User {
         guard let user = self._currentUser else {
@@ -215,8 +164,6 @@ class UserPersistence {
         
         userDefaults.set(nil, forKey: currentUserKey)
         keychains.delete(currentUserKey)
-        
-        self.userProfileImage = nil
     }
 }
 

--- a/Breezy-Traveler/PersistenceUser.swift
+++ b/Breezy-Traveler/PersistenceUser.swift
@@ -25,7 +25,8 @@ class UserPersistence {
             
             networking.upload(profile: scaledImage) { result in
                 switch result {
-                case .success(_):
+                case .success(let updatedUser):
+                    self.setCurrentUser(updatedUser, writeToPersistence: true)
                     completion(true)
                 case .failure(let err):
                     assertionFailure(err.localizedDescription)
@@ -35,6 +36,8 @@ class UserPersistence {
             }
         } else {
             //TODO: erick-clear user profile image
+            
+            //TODO: clear kingfisher cache (mabye don't need to clear cache when image changes)
 //            networking.clearProfileImage { result in
 //
 //            }

--- a/Breezy-Traveler/PersistenceUser.swift
+++ b/Breezy-Traveler/PersistenceUser.swift
@@ -13,6 +13,34 @@ class UserPersistence {
     
     // MARK: - VARS
     
+    func updateUserProfileImage(_ image: UIImage?, completion: @escaping (Bool) -> Void) {
+        let networking = NetworkStack()
+        
+        if let image = image {
+            guard let scaledImage = image.resize(to: CGSize.userProfileSize) else {
+                assertionFailure("Failed to resize image")
+                
+                return completion(false)
+            }
+            
+            networking.upload(profile: scaledImage) { result in
+                switch result {
+                case .success(_):
+                    completion(true)
+                case .failure(let err):
+                    assertionFailure(err.localizedDescription)
+                    
+                    completion(false)
+                }
+            }
+        } else {
+            //TODO: erick-clear user profile image
+//            networking.clearProfileImage { result in
+//
+//            }
+        }
+    }
+    
     var userProfileImage: UIImage? {
         set {
             if let newImage = newValue {
@@ -191,4 +219,8 @@ class UserPersistence {
 
 extension NSNotification.Name {
     static let userDidLogout = NSNotification.Name.init("USER_DID_LOGOUT")
+}
+
+extension CGSize {
+    static let userProfileSize = CGSize(width: 512, height: 512)
 }

--- a/Breezy-Traveler/ProfileViewController.swift
+++ b/Breezy-Traveler/ProfileViewController.swift
@@ -33,11 +33,8 @@ class ProfileViewController: UIViewController, UIImagePickerControllerDelegate, 
     // MARK: - METHODS
     
     private func updateUI() {
-        if let storedImage = userPersistence.userProfileImage {
-            imageView.image = storedImage
-        }
-        
         let user = UserPersistence.currentUser
+        imageView.kf.setImage(with: user.profileUrl)
         usernameLabel.text = user.username
         emailLabel.text = user.email
         fullnameLabel.text = user.username

--- a/Breezy-Traveler/ProfileViewController.swift
+++ b/Breezy-Traveler/ProfileViewController.swift
@@ -131,11 +131,27 @@ extension ProfileViewController {
         
         let rotatedImage = fixOrientation(img: pickedImage)
         
-        userPersistence.userProfileImage = rotatedImage
-        imageView.contentMode = .scaleAspectFill
-        imageView.image = pickedImage
-        
+        // dismis the image picker
         dismiss(animated: true, completion: nil)
+        
+        //TODO: present loading spinner
+        view.isUserInteractionEnabled = false
+        
+        userPersistence.updateUserProfileImage(rotatedImage) { [weak self] (isSuccessful) in
+            guard let unwrappedSelf = self else { return }
+            
+            if isSuccessful {
+                unwrappedSelf.imageView.contentMode = .scaleAspectFill
+                unwrappedSelf.imageView.image = rotatedImage
+            } else {
+                UIAlertController(title: "Updating Profile Image", message: "Something went wrong", preferredStyle: .alert)
+                    .addDismissButton()
+                    .present(in: unwrappedSelf)
+            }
+            
+            //TODO: dismiss loading spinner
+            unwrappedSelf.view.isUserInteractionEnabled = true
+        }
     }
     
     func imagePickerController(didFinishPickingMediaWithInfo info: [String : AnyObject]) {

--- a/Breezy-Traveler/UserModel.swift
+++ b/Breezy-Traveler/UserModel.swift
@@ -28,11 +28,13 @@ struct User: Codable {
         var name: String
     }
     var facebook: Facebook?
+    let profileImage: String?
     
     enum CodingKeys: String, CodingKey {
         case id = "_id"
         case local
         case facebook
+        case profileImage
     }
     
     var username: String {

--- a/Breezy-Traveler/UtilityExtensions.swift
+++ b/Breezy-Traveler/UtilityExtensions.swift
@@ -14,10 +14,7 @@ extension UIImage {
         return #imageLiteral(resourceName: "MountainsDefault")
     }
     
-    func resize(to size: CGSize) -> UIImage? {
-        let scale = size.width / self.size.width
-        let newHeight = self.size.height * scale
-        
+    func resize(to size: CGSize) -> UIImage? {        
         UIGraphicsBeginImageContext(size)
         self.draw(in: CGRect(origin: CGPoint.zero, size: size))
         let newImage = UIGraphicsGetImageFromCurrentImageContext()

--- a/Breezy-Traveler/UtilityExtensions.swift
+++ b/Breezy-Traveler/UtilityExtensions.swift
@@ -13,6 +13,18 @@ extension UIImage {
     static var defaultCoverImage: UIImage {
         return #imageLiteral(resourceName: "MountainsDefault")
     }
+    
+    func resize(to size: CGSize) -> UIImage? {
+        let scale = size.width / self.size.width
+        let newHeight = self.size.height * scale
+        
+        UIGraphicsBeginImageContext(size)
+        self.draw(in: CGRect(origin: CGPoint.zero, size: size))
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return newImage
+    }
 }
 
 extension Collection where Index : Comparable {


### PR DESCRIPTION
closes #166 

# What's New
- Add Networking endpoint to POST a new profile image
- Removed local persistence of user profile image
- Use Kingfisher to fetch the user profile image

# TODO
- [ ] clearing the user profile endpoint