### PR TITLE
Relogin User

### DIFF
--- a/Breezy-Traveler.xcodeproj/project.pbxproj
+++ b/Breezy-Traveler.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		E996A4B920CCD48900A0038E /* TripDetailedNotesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E996A4B820CCD48900A0038E /* TripDetailedNotesViewController.swift */; };
 		E996A4BB20CDFF5E00A0038E /* UserfacingErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = E996A4BA20CDFF5E00A0038E /* UserfacingErrors.swift */; };
 		E996A4BD20CE1CA300A0038E /* UserfacingErrors+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = E996A4BC20CE1CA300A0038E /* UserfacingErrors+User.swift */; };
+		E9A6B4B321D454EE00667FEB /* LoginLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A6B4B221D454EE00667FEB /* LoginLayer.swift */; };
+		E9A6B4B521D45EF800667FEB /* ThrottleGlobalFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A6B4B421D45EF800667FEB /* ThrottleGlobalFunctions.swift */; };
 		E9A91C2821BA14A4007BBF6F /* ResourceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A91C2721BA14A4007BBF6F /* ResourceViewController.swift */; };
 		E9A91C2B21BADD87007BBF6F /* ResourceView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E9A91C2921BADA94007BBF6F /* ResourceView.xib */; };
 		E9A91C2D21BAE4F8007BBF6F /* UtitlityExtensions+Pluralize.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A91C2C21BAE4F8007BBF6F /* UtitlityExtensions+Pluralize.swift */; };
@@ -145,6 +147,8 @@
 		E996A4B820CCD48900A0038E /* TripDetailedNotesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripDetailedNotesViewController.swift; sourceTree = "<group>"; };
 		E996A4BA20CDFF5E00A0038E /* UserfacingErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserfacingErrors.swift; sourceTree = "<group>"; };
 		E996A4BC20CE1CA300A0038E /* UserfacingErrors+User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserfacingErrors+User.swift"; sourceTree = "<group>"; };
+		E9A6B4B221D454EE00667FEB /* LoginLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLayer.swift; sourceTree = "<group>"; };
+		E9A6B4B421D45EF800667FEB /* ThrottleGlobalFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrottleGlobalFunctions.swift; sourceTree = "<group>"; };
 		E9A91C2721BA14A4007BBF6F /* ResourceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceViewController.swift; sourceTree = "<group>"; };
 		E9A91C2921BADA94007BBF6F /* ResourceView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ResourceView.xib; sourceTree = "<group>"; };
 		E9A91C2C21BAE4F8007BBF6F /* UtitlityExtensions+Pluralize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UtitlityExtensions+Pluralize.swift"; sourceTree = "<group>"; };
@@ -245,6 +249,8 @@
 				B9F9F17B20756B0700F0D24D /* PersistenceUser.swift */,
 				B9F9F17D20758E5F00F0D24D /* AlertVC.swift */,
 				E98036DD21C9BA8F002344C7 /* KeyboardHelper.swift */,
+				E9A6B4B221D454EE00667FEB /* LoginLayer.swift */,
+				E9A6B4B421D45EF800667FEB /* ThrottleGlobalFunctions.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -597,6 +603,7 @@
 				E934F2DE21B86EBD00553138 /* HotelsViewModel.swift in Sources */,
 				E9A91C2D21BAE4F8007BBF6F /* UtitlityExtensions+Pluralize.swift in Sources */,
 				E97B4E8520CB24AD0018036D /* PublishedTripsVc.swift in Sources */,
+				E9A6B4B321D454EE00667FEB /* LoginLayer.swift in Sources */,
 				E97ED75B2077EF140021B651 /* UIButtonCell.swift in Sources */,
 				E996A4B920CCD48900A0038E /* TripDetailedNotesViewController.swift in Sources */,
 				E91A196720840D0C00CEE74A /* TripDetailedViewController.swift in Sources */,
@@ -614,6 +621,7 @@
 				E9A91C3121BAE793007BBF6F /* SitesViewModel.swift in Sources */,
 				E9189FD421C330E500C4132A /* Once.swift in Sources */,
 				B940C850206EEB3100E7144D /* TripModel.swift in Sources */,
+				E9A6B4B521D45EF800667FEB /* ThrottleGlobalFunctions.swift in Sources */,
 				E98F034C2072B69C004D4074 /* Hotel.swift in Sources */,
 				E95E13842075651F00BF4276 /* BTSite.swift in Sources */,
 				E96BEF8620CCBC9600295ECD /* NetworkingLayer+QOD.swift in Sources */,

--- a/Breezy-Traveler/API.swift
+++ b/Breezy-Traveler/API.swift
@@ -326,8 +326,6 @@ fileprivate func handleStatus(_ result: Result<Response, MoyaError>, _ statusCod
         case 401:
             let user = LoginLayer.instance
             user.needsLogin()
-        case 409:
-            fail(UserfacingErrors.duplicateAccount())
         default:
             fail(UserfacingErrors.serverError(message: response.data))
         }

--- a/Breezy-Traveler/HotelsViewModel.swift
+++ b/Breezy-Traveler/HotelsViewModel.swift
@@ -107,12 +107,11 @@ class HotelsViewModel: ResourceViewModel {
             guard let unwrappedSelf = self else { return }
             
             switch result {
-            case .success(let message):
+            case .success:
                 if let indexToRemove = unwrappedSelf.resource.firstIndex(where: { $0.id == resource.id }) {
                     unwrappedSelf.resource.remove(at: indexToRemove)
                 }
                 
-                debugPrint(message)
                 completion(true)
             case .failure(let err):
                 assertionFailure(err.localizedDescription)

--- a/Breezy-Traveler/LoginLayer.swift
+++ b/Breezy-Traveler/LoginLayer.swift
@@ -1,0 +1,24 @@
+//
+//  LoginLayer.swift
+//  Breezy-Traveler
+//
+//  Created by Erick Sanchez on 12/26/18.
+//  Copyright © 2018 Phyllis Wong. All rights reserved.
+//
+
+import Foundation
+
+protocol LoginLayerDelegate: class {
+    func userNeedsToLogin(_ loginLayer: LoginLayer)
+}
+
+class LoginLayer {
+    
+    static let instance = LoginLayer()
+    
+    weak var delegate: LoginLayerDelegate?
+    
+    func needsLogin() {
+        delegate?.userNeedsToLogin(self)
+    }
+}

--- a/Breezy-Traveler/NetworkingLayer+Hotels.swift
+++ b/Breezy-Traveler/NetworkingLayer+Hotels.swift
@@ -14,129 +14,41 @@ import SwiftyJSON
 extension NetworkStack {
     
     func create(a hotel: CreateHotel, for trip: Trip, callback: @escaping (Result<Hotel, UserfacingErrors>) -> ()) {
-        apiService.request(.createHotel(hotel, for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                    
-                // Created
-                case 201:
-                    guard let returnedHotel = try? JSONDecoder().decode(Hotel.self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(returnedHotel))
-                    
-                // Unhandled codes
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .createHotel(hotel, for: trip),
+            completion: jsonResponse(expectedSuccessCode: 201, next: callback)
+        )
     }
     
     func loadHotels(for trip: Trip, callback: @escaping (Result<[Hotel], UserfacingErrors>) -> ()) {
-        apiService.request(.loadHotels(for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let hotels = try? JSONDecoder().decode([Hotel].self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(hotels))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .loadHotels(for: trip),
+            completion: jsonResponse(next: callback)
+        )
     }
     
     func showHotel(for hotelId: Int, for trip: Trip, callback: @escaping (Result<Hotel, UserfacingErrors>) -> ()) {
-        apiService.request(.showHotel(forHotelId: hotelId, for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let hotel = try? JSONDecoder().decode(Hotel.self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(hotel))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .showHotel(forHotelId: hotelId, for: trip),
+            completion: jsonResponse(next: callback)
+        )
     }
     
     func update(hotel: Hotel, for trip: Trip, callback: @escaping (Result<Hotel, UserfacingErrors>) -> ()) {
-        apiService.request(.updateHotel(hotel, for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let updatedHotel = try? JSONDecoder().decode(Hotel.self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(updatedHotel))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .updateHotel(hotel, for: trip),
+            completion: jsonResponse(next: callback)
+        )
     }
     
-    func delete(hotel: Hotel, for trip: Trip, callback: @escaping (Result<String, UserfacingErrors>) -> ()) {
-        apiService.request(.deleteHotel(hotel, for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 202:
-                    callback(.success("\(hotel.name) was deleted"))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+    func delete(hotel: Hotel, for trip: Trip, callback: @escaping (Result<Hotel, UserfacingErrors>) -> ()) {
+        apiService.request(
+            .deleteHotel(hotel, for: trip),
+            completion: jsonResponse(expectedSuccessCode: 202, successfulResponse: { (response) in
+                callback(.success(hotel))
+            }, failureResponse: { (userError) in
+                callback(.failure(userError))
+            })
+        )
     }
 }

--- a/Breezy-Traveler/NetworkingLayer+Sites.swift
+++ b/Breezy-Traveler/NetworkingLayer+Sites.swift
@@ -13,129 +13,41 @@ import SwiftyJSON
 
 extension NetworkStack {
     func create(a site: CreateSite, for trip: Trip, callback: @escaping (Result<Site, UserfacingErrors>) -> ()) {
-        apiService.request(.createSite(site, for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                    
-                // Created
-                case 201:
-                    guard let returnedSite = try? JSONDecoder().decode(Site.self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(returnedSite))
-                    
-                // Unhandled codes
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .createSite(site, for: trip),
+            completion: jsonResponse(expectedSuccessCode: 201, next: callback)
+        )
     }
     
     func loadSites(for trip: Trip, callback: @escaping (Result<[Site], UserfacingErrors>) -> ()) {
-        apiService.request(.loadSites(for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let sites = try? JSONDecoder().decode([Site].self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(sites))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .loadSites(for: trip),
+            completion: jsonResponse(next: callback)
+        )
     }
     
     func showSite(for siteId: Int, for trip: Trip, callback: @escaping (Result<Site, UserfacingErrors>) -> ()) {
-        apiService.request(.showSite(forSiteId: siteId, for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let site = try? JSONDecoder().decode(Site.self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(site))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .showSite(forSiteId: siteId, for: trip),
+            completion: jsonResponse(next: callback)
+        )
     }
     
     func update(site: Site, for trip: Trip, callback: @escaping (Result<Site, UserfacingErrors>) -> ()) {
-        apiService.request(.updateSite(site, for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let updatedSite = try? JSONDecoder().decode(Site.self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(updatedSite))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .updateSite(site, for: trip),
+            completion: jsonResponse(next: callback)
+        )
     }
     
-    func delete(site: Site, for trip: Trip, callback: @escaping (Result<String, UserfacingErrors>) -> ()) {
-        apiService.request(.deleteSite(site, for: trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 202:
-                    callback(.success("\(site.name) was deleted"))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+    func delete(site: Site, for trip: Trip, callback: @escaping (Result<Site, UserfacingErrors>) -> ()) {
+        apiService.request(
+            .deleteSite(site, for: trip),
+            completion: jsonResponse(expectedSuccessCode: 202, successfulResponse: { (response) in
+                callback(.success(site))
+            }, failureResponse: { (userError) in
+                callback(.failure(userError))
+            })
+        )
     }
 }

--- a/Breezy-Traveler/NetworkingLayer+Trips.swift
+++ b/Breezy-Traveler/NetworkingLayer+Trips.swift
@@ -14,36 +14,10 @@ import SwiftyJSON
 extension NetworkStack {
     
     func loadUserTrips(user: User, callback: @escaping (Result<[Trip], UserfacingErrors>) -> ()) {
-        /// handles the response data after the networkService has fired and come back with a result
-        apiService.request(.loadTrips(user)) { (result) in
-            switch result {
-            
-            case .success(let response):
-                
-                //TODO: handle 401
-                switch response.statusCode {
-                case 200:
-                    guard let trips = try? JSONDecoder.trips(from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(trips))
-                case 401: //needs relogin
-                    let user = LoginLayer.instance
-                    user.needsLogin()
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .loadTrips(user),
+            completion: jsonResponse(decoder: .tripsDecoder, next: callback)
+        )
     }
     
     func createTrip(trip: CreateTrip, callback: @escaping (Result<Trip, UserfacingErrors>) -> ()) {

--- a/Breezy-Traveler/NetworkingLayer+Trips.swift
+++ b/Breezy-Traveler/NetworkingLayer+Trips.swift
@@ -44,7 +44,7 @@ extension NetworkStack {
     func deleteTrip(trip: Trip, callback: @escaping (Result<Trip, UserfacingErrors>) -> ()) {
         apiService.request(
             .deleteTrip(trip),
-            completion: jsonResponse(expectedSuccessCode: 204, successfulResponse: { (response) in
+            completion: jsonResponse(expectedSuccessCode: 202, successfulResponse: { (response) in
                 callback(.success(trip))
             }, failureResponse: { (userError) in
                 callback(.failure(userError))

--- a/Breezy-Traveler/NetworkingLayer+Trips.swift
+++ b/Breezy-Traveler/NetworkingLayer+Trips.swift
@@ -31,6 +31,9 @@ extension NetworkStack {
                     }
                     
                     callback(.success(trips))
+                case 401: //needs relogin
+                    let user = LoginLayer.instance
+                    user.needsLogin()
                 default:
                     let errors = UserfacingErrors.serverError(message: response.data)
                     callback(.failure(errors))
@@ -158,6 +161,10 @@ extension NetworkStack {
                     }
                     
                     callback(.success(trips))
+                case 401: //needs relogin
+                    let user = LoginLayer.instance
+                    user.needsLogin()
+                    
                 default:
                     let errors = UserfacingErrors.serverError(message: response.data)
                     callback(.failure(errors))

--- a/Breezy-Traveler/NetworkingLayer+Trips.swift
+++ b/Breezy-Traveler/NetworkingLayer+Trips.swift
@@ -20,6 +20,7 @@ extension NetworkStack {
             
             case .success(let response):
                 
+                //TODO: handle 401
                 switch response.statusCode {
                 case 200:
                     guard let trips = try? JSONDecoder.trips(from: response.data) else {

--- a/Breezy-Traveler/NetworkingLayer+Trips.swift
+++ b/Breezy-Traveler/NetworkingLayer+Trips.swift
@@ -21,161 +21,49 @@ extension NetworkStack {
     }
     
     func createTrip(trip: CreateTrip, callback: @escaping (Result<Trip, UserfacingErrors>) -> ()) {
-        apiService.request(.createTrip(trip)) { (result) in
-            switch result {
-            case .success(let response):
-                
-                switch response.statusCode {
-                case 201:
-                    guard let trip = try? JSONDecoder.trip(from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(trip))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .createTrip(trip),
+            completion: jsonResponse(expectedSuccessCode: 201, decoder: .tripsDecoder, next: callback)
+        )
     }
     
     func showTrip(for id: String, callback: @escaping (Result<Trip, UserfacingErrors>) -> ()) {
-        apiService.request(.showTrip(forTripID: id)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let trip = try? JSONDecoder.trip(from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(trip))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .showTrip(forTripID: id),
+            completion: jsonResponse(decoder: .tripsDecoder, next: callback)
+        )
     }
     
     func update(trip: Trip, callback: @escaping (Result<Trip, UserfacingErrors>) -> ()) {
-        apiService.request(.updateTrip(trip)) { (result) in
-            switch result {
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let updatedTrip = try? JSONDecoder.trip(from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(updatedTrip))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .updateTrip(trip),
+            completion: jsonResponse(decoder: .tripsDecoder, next: callback)
+        )
     }
     
-    
     func deleteTrip(trip: Trip, callback: @escaping (Result<Trip, UserfacingErrors>) -> ()) {
-        apiService.request(.deleteTrip(trip)) { (result) in
-            switch result {
-                
-            case .success(let response):
-                switch response.statusCode {
-                case 204:
-                    callback(.success(trip))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .deleteTrip(trip),
+            completion: jsonResponse(expectedSuccessCode: 204, successfulResponse: { (response) in
+                callback(.success(trip))
+            }, failureResponse: { (userError) in
+                callback(.failure(userError))
+            })
+        )
     }
     
     func loadPublishedTrips(fetchAllTrips: Bool, callback: @escaping (Result<[Trip], UserfacingErrors>) -> ()) {
-        apiService.request(.loadPublishedTrips(fetchAll: fetchAllTrips)) { (result) in
-            switch result {
-                
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let trips = try? JSONDecoder.trips(from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(trips))
-                case 401: //needs relogin
-                    let user = LoginLayer.instance
-                    user.needsLogin()
-                    
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .loadPublishedTrips(fetchAll: fetchAllTrips),
+            completion: jsonResponse(decoder: .tripsDecoder, next: callback)
+        )
     }
     
     func loadPublishedTrips(for searchTerm: String, callback: @escaping (Result<[Trip], UserfacingErrors>) -> ()) {
-        apiService.request(.searchPublishedTrips(searchTerm: searchTerm)) { (result) in
-            switch result {
-                
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let trips = try? JSONDecoder.trips(from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(trips))
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .searchPublishedTrips(searchTerm: searchTerm),
+            completion: jsonResponse(decoder: .tripsDecoder, next: callback)
+        )
     }
 }
 

--- a/Breezy-Traveler/NteworkingLayer+Images.swift
+++ b/Breezy-Traveler/NteworkingLayer+Images.swift
@@ -14,30 +14,9 @@ import SwiftyJSON
 extension NetworkStack {
     
     func fetchImages(searchTerm: String, callback: @escaping (Result<[URL], UserfacingErrors>) -> ()) {
-        apiService.request(.loadTenImages(searchTerm)) { (result) in
-            switch result {
-                
-            case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let urlArray = try? JSONDecoder().decode([URL].self, from: response.data) else {
-                        assertionFailure("JSON data not decodable")
-                        
-                        let errors = UserfacingErrors.somethingWentWrong()
-                        return callback(.failure(errors))
-                    }
-                    
-                    callback(.success(urlArray))
-                    
-                default:
-                    let errors = UserfacingErrors.serverError(message: response.data)
-                    callback(.failure(errors))
-                }
-                
-            case .failure(let err):
-                let errors = UserfacingErrors.somethingWentWrong(message: err.localizedDescription)
-                callback(.failure(errors))
-            }
-        }
+        apiService.request(
+            .loadTenImages(searchTerm),
+            completion: jsonResponse(next: callback)
+        )
     }
 }

--- a/Breezy-Traveler/SitesViewModel.swift
+++ b/Breezy-Traveler/SitesViewModel.swift
@@ -107,12 +107,11 @@ class SitesViewModel: ResourceViewModel {
             guard let unwrappedSelf = self else { return }
             
             switch result {
-            case .success(let message):
+            case .success:
                 if let indexToRemove = unwrappedSelf.resource.firstIndex(where: { $0.id == resource.id }) {
                     unwrappedSelf.resource.remove(at: indexToRemove)
                 }
                 
-                debugPrint(message)
                 completion(true)
             case .failure(let err):
                 assertionFailure(err.localizedDescription)

--- a/Breezy-Traveler/ThrottleGlobalFunctions.swift
+++ b/Breezy-Traveler/ThrottleGlobalFunctions.swift
@@ -1,0 +1,200 @@
+
+import Foundation
+
+protocol ThrottlerDelegate: class {
+    func throttler(_ throttler: Throttler, didExecuteJobAt lastExecutionDate: Date?)
+    
+    /**
+     when the timer has exceeded from last execution
+     */
+    func throttlerDidFinishCycle(_ throttler: Throttler)
+}
+
+class Throttler {
+    
+    var job: DispatchWorkItem!
+    var isCanceled: Bool {
+        return job.isCancelled
+    }
+    
+    var maxInterval: Int
+    
+    private var cycleTimer: Timer?
+    private var previousRun: Date? {
+        didSet {
+            self.cycleTimer?.invalidate()
+            self.cycleTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(maxInterval), repeats: false, block: { (_) in
+                self.delegate?.throttlerDidFinishCycle(self)
+            })
+        }
+    }
+    
+    var queue: DispatchQueue
+    
+    weak var delegate: ThrottlerDelegate?
+    
+    init(maxInterval: Int, queue: DispatchQueue = DispatchQueue.main, delegate: ThrottlerDelegate?) {
+        self.maxInterval = maxInterval
+        self.queue = queue
+        self.delegate = delegate
+    }
+    
+    func invoke(block: @escaping () -> Void) {
+        guard self.previousRun == nil else { return }
+        
+        self.job = DispatchWorkItem(block: {
+            self.previousRun = Date()
+            block()
+        })
+        
+        job.notify(queue: queue) {
+            self.delegate?.throttler(self, didExecuteJobAt: self.previousRun)
+        }
+         
+        queue.async(execute: self.job)
+    }
+}
+
+class PostThrottler: Throttler {
+    
+    private var firstInvoke: Date?
+    
+    override func invoke(block: @escaping () -> Void) {
+        let delay: Int
+        
+        //is there a previous invoke scheduled?
+        if let firstInvoke = self.firstInvoke {
+            self.job.cancel()
+            delay = self.maxInterval - Date.seconds(from: firstInvoke)
+            
+        //store the first invoke
+        } else {
+            delay = self.maxInterval
+            self.firstInvoke = Date()
+        }
+        
+        self.job = DispatchWorkItem(block: {
+            self.firstInvoke = Date()
+            block()
+        })
+        
+        job.notify(queue: queue) {
+            self.delegate?.throttler(self, didExecuteJobAt: self.firstInvoke)
+        }
+        
+        self.queue.asyncAfter(deadline: .now() + Double(delay), execute: self.job)
+    }
+}
+
+class ContinuousThrottler: Throttler {
+    
+    private var cycleTimer: Timer?
+    private var mostRecentInvoke: Date? {
+        didSet {
+            self.cycleTimer?.invalidate()
+            self.cycleTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(maxInterval), repeats: false, block: { (_) in
+                self.delegate?.throttlerDidFinishCycle(self)
+            })
+        }
+    }
+    
+    override func invoke(block: @escaping () -> Void) {
+        if self.mostRecentInvoke != nil {
+            self.job.cancel()
+        }
+        
+        self.mostRecentInvoke = Date()
+        let delay = self.maxInterval
+        
+        self.job = DispatchWorkItem(block: {
+            block()
+        })
+        
+        job.notify(queue: queue) {
+            self.delegate?.throttler(self, didExecuteJobAt: self.mostRecentInvoke)
+        }
+        
+        self.queue.asyncAfter(deadline: .now() + Double(delay), execute: self.job)
+    }
+}
+
+class ThrottleSingleton: ThrottlerDelegate {
+    static var shared = ThrottleSingleton()
+    
+    private var throttles: [String: Throttler] = [:]
+    
+    subscript(_ identifier: String) -> Throttler? {
+        set {
+            throttles[identifier] = newValue
+        }
+        get {
+            return throttles[identifier]
+        }
+    }
+    
+    private init() { }
+    
+    // MARK: - RETURN VALUES
+    
+    // MARK: - VOID METHODS
+    
+    func throttler(_ throttler: Throttler, didExecuteJobAt lastExecutionDate: Date?) {
+    }
+    
+    func throttlerDidFinishCycle(_ throttler: Throttler) {
+        if let indexToRemove = throttles.index(where: { keyValuePair in keyValuePair.value === throttler }) {
+            throttles.remove(at: indexToRemove)
+        }
+    }
+    
+    // MARK: - IBACTIONS
+    
+    // MARK: - LIFE CYCLE
+}
+
+public func throttle(for seconds: Int, identifier: String = #function, block: @escaping () -> Void) {
+    let manager = ThrottleSingleton.shared
+    guard manager[identifier] == nil else { return }
+    
+    let throttler = Throttler(maxInterval: seconds, delegate: manager)
+    manager[identifier] = throttler
+    
+    throttler.invoke(block: block)
+}
+
+public func postThrottle(for seconds: Int, identifier: String = #function, block: @escaping () -> Void) {
+    let manager = ThrottleSingleton.shared
+    
+    let throttler: Throttler
+    
+    if let exisitingThrottler = manager[identifier] {
+        throttler = exisitingThrottler
+    } else {
+        throttler = PostThrottler(maxInterval: seconds, delegate: manager)
+        manager[identifier] = throttler
+    }
+    
+    throttler.invoke(block: block)
+}
+
+public func continuousThrottle(for seconds: Int, identifier: String = #function, block: @escaping () -> Void) {
+    let manager = ThrottleSingleton.shared
+    
+    let throttler: Throttler
+    
+    if let exisitingThrottler = manager[identifier] {
+        throttler = exisitingThrottler
+    } else {
+        throttler = ContinuousThrottler(maxInterval: seconds, delegate: manager)
+        manager[identifier] = throttler
+    }
+    
+    throttler.invoke(block: block)
+}
+
+private extension Date {
+    static func seconds(from referenceDate: Date) -> Int {
+        return Int(Date().timeIntervalSince(referenceDate).rounded())
+    }
+}
+

--- a/Breezy-Traveler/UserfacingErrors.swift
+++ b/Breezy-Traveler/UserfacingErrors.swift
@@ -31,6 +31,10 @@ struct UserfacingErrors: Error {
         return UserfacingErrors(dataErrorMessage: message)
     }
     
+    static func duplicateAccount() -> UserfacingErrors {
+        return UserfacingErrors(errors: ["Account already exists"])
+    }
+    
     init(errors: [String]) {
         self.errors = errors
     }


### PR DESCRIPTION
### What's New
- When a request, except for `\login` and `\register`, respond back with a 401, the AppDelegate will set the rootViewController to be the LoginController.

### What's Changed
- The networking layer for trips, hotels, sites, and Getty images have been refactored to handle the generic status codes (200, 201, 202, 401, and server errors). In also includes when Moya responds with its own error

closes #171 